### PR TITLE
fix: changing width of tabs when selected

### DIFF
--- a/src/components/Elements/Tab.tsx
+++ b/src/components/Elements/Tab.tsx
@@ -16,21 +16,31 @@ const BaseTab: FC<BaseTabProps> = ({ text, icon, className }) => {
           twJoin(
             'relative cursor-pointer select-none rounded bg-transparent px-2 py-1 text-sm hover:bg-gray-100 focus:outline-none',
             'transition duration-100 ease-in-out',
-            // GitHub-like line below the selected tab
+
             selected &&
-              'font-semibold after:absolute after:bottom-[calc(50%-23px)] after:left-0 after:z-10 after:h-[2px] after:w-[100%] after:rounded after:bg-gradient-to-r after:from-red-700 after:to-red-500',
+              'after:absolute after:bottom-[calc(50%-23px)] after:left-0 after:z-10 after:h-[2px] after:w-[100%] after:rounded after:bg-gradient-to-r after:from-red-700 after:to-red-500',
+            selected ? 'font-semibold' : 'font-normal',
           ),
           className,
         )
       }
     >
-      <span className="flex items-center space-x-2">
-        {icon}
+      <span className="inline-flex items-center space-x-2">
+        {icon && <span className="tab-icon">{icon}</span>}
         <>
-          <span>{text}</span>
-          {/* TODO: Add an invisible semibold text here, so that when the tab switches from normal to semibold, the width doesn't change */}
-          {/* Or alternatively think of a way to make the width not change when the tab switches from normal to semibold */}
-          {/* Take note from GitHub repos */}
+          <span
+            className="tab-text overflow-hidden truncate whitespace-nowrap"
+            style={{ maxWidth: '150px' }}
+          >
+            <span
+              title={text}
+              className="
+              after:visibility-hidden after:block after:h-0 after:overflow-hidden after:font-semibold after:content-[attr(title)]
+            "
+            >
+              {text}
+            </span>
+          </span>
         </>
       </span>
     </HeadlessUiTab>


### PR DESCRIPTION
Use after selector to fix the issue of changing width of the tab due to the bolding of the text when the tab is selected